### PR TITLE
Исправление каста в LLVM IR

### DIFF
--- a/mono/m_test.d
+++ b/mono/m_test.d
@@ -1,8 +1,8 @@
 module mono.m_test;
 
-extern(C) int sum() nothrow @nogc
+extern(C) int sum(const int a, const int b) nothrow @nogc
 {
-    return 15;
+    return a+b;
 }
 
 extern(C) void echo(const char* str) nothrow

--- a/mono/mono.toml
+++ b/mono/mono.toml
@@ -1,7 +1,7 @@
 [[function]]
 name = "sum"
 ret = "i32"
-args = []
+args = ["i32","i32"]
 
 [[function]]
 name = "concat"


### PR DESCRIPTION
Когда загружалась переменная, она загружалась как ожидаемый тип аргумента а не как она есть, что хуярило такие ситуации что i1 вызывается в load как i32